### PR TITLE
Add favicon & fix page title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Link Tracker</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#111111"/>
+  <!-- Left chain link (horizontal oval) -->
+  <rect x="3" y="11" width="14" height="10" rx="5" ry="5"
+        fill="none" stroke="#C9A84C" stroke-width="2.8"/>
+  <!-- Right chain link (horizontal oval) -->
+  <rect x="15" y="11" width="14" height="10" rx="5" ry="5"
+        fill="none" stroke="#C9A84C" stroke-width="2.8"/>
+  <!-- Overlap mask: black bar over left link's right side to create chain effect -->
+  <rect x="17.5" y="12.4" width="5" height="7.2" fill="#111111"/>
+</svg>


### PR DESCRIPTION
Closes #12

## Changes
- 🔗 Added custom chain-link SVG favicon (`frontend/public/favicon.svg`) — gold (#C9A84C) on dark background
- 📝 Fixed page title from `frontend` to `Link Tracker`
- 🔗 Replaced default Vite favicon with `/favicon.svg` in `index.html`